### PR TITLE
Fix Boost link flags in pkg-config file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Unreleased
   - Changes from 5.25.0
+    - Build:
+      - FIXED: Fixed Boost link flags in pkg-config file. [#6081](https://github.com/Project-OSRM/osrm-backend/pull/6081)
     - Features
       - FIXED: Completed support for no_entry and no_exit turn restrictions. [#5988](https://github.com/Project-OSRM/osrm-backend/pull/5988)
       - ADDED: Support snapping to multiple ways at an input location. [#5953](https://github.com/Project-OSRM/osrm-backend/pull/5953)
       - CHANGED: Breaking change to libosrm `hints` parameter. It now takes a vector of `Hint` objects for each request coordinate. [#5953](https://github.com/Project-OSRM/osrm-backend/pull/5953)
     - Routing:
       - CHANGED: Lazily generate optional route path data [#6045](https://github.com/Project-OSRM/osrm-backend/pull/6045)
-
 # 5.25.0
   - Changes from 5.24.0
     - Build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.2)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR AND NOT MSVC_IDE)
   message(FATAL_ERROR "In-source builds are not allowed.
@@ -802,9 +802,25 @@ set(PKGCONFIG_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include")
 list(APPEND DEPENDENCIES_INCLUDE_DIRS "${PKGCONFIG_INCLUDE_DIR}")
 list(APPEND DEPENDENCIES_INCLUDE_DIRS "${PKGCONFIG_INCLUDE_DIR}/osrm")
 JOIN("-I${DEPENDENCIES_INCLUDE_DIRS}" " -I" PKGCONFIG_OSRM_INCLUDE_FLAGS)
-JOIN("${ENGINE_LIBRARIES}" " " PKGCONFIG_OSRM_DEPENDENT_LIBRARIES)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkgconfig.in libosrm.pc @ONLY)
+# Boost uses imported targets, we need to use a generator expression to extract
+# the link libraries to be written to the pkg-config file.
+foreach(engine_lib ${ENGINE_LIBRARIES})
+  if("${engine_lib}" MATCHES "^Boost.*")
+    list(APPEND PKGCONFIG_DEPENDENT_LIBRARIES "$<TARGET_LINKER_FILE:${engine_lib}>")
+  else()
+    list(APPEND PKGCONFIG_DEPENDENT_LIBRARIES "${engine_lib}")
+  endif()
+endforeach(engine_lib)
+JOIN("${PKGCONFIG_DEPENDENT_LIBRARIES}" " " PKGCONFIG_OSRM_DEPENDENT_LIBRARIES)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkgconfig.in pkgconfig.configured @ONLY)
+file(GENERATE
+     OUTPUT
+     ${PROJECT_BINARY_DIR}/libosrm.pc
+     INPUT
+     ${PROJECT_BINARY_DIR}/pkgconfig.configured)
+
 install(FILES ${PROJECT_BINARY_DIR}/libosrm.pc DESTINATION ${PKGCONFIG_LIBRARY_DIR}/pkgconfig)
 
 # uninstall target


### PR DESCRIPTION
# Issue

In newer versions of cmake, [FindBoost](https://cmake.org/cmake/help/latest/module/FindBoost.html) uses [Imported Targets ](https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html)for library component variables, rather than file paths to the Boost libraries.

cmake uses these targets when linking (e.g. `target_link_library`) and knows how to correctly substitute the values. However, the OSRM pkg-config file that we generate doesn't do this, and ends up writing the actual target symbols, hence the errors trying to link `Boost::<component>`.

To fix this for newer cmake versions, we create an intermediate configure step that references [TARGET_LINKER_FILE](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:TARGET_LINKER_FILE) for each imported target. This is followed by a `file(GENERATE` step that performs the correct substitution.
See this thread for more details: https://cmake.org/pipermail/cmake/2018-December/068812.html

This is backwards compatible to the existing min cmake version (3.1). However, building using cmake 3.1 fails with an unrelated package.json parsing error:
```bash
CMake Error at cmake/JSONParser.cmake:287 (string):
  string end index: 1 is out of range -1 - 0
Call Stack (most recent call first):
  cmake/JSONParser.cmake:232 (_sbeMoveToNextNonEmptyCharacter)
  cmake/JSONParser.cmake:71 (_sbeParseObject)
  cmake/JSONParser.cmake:22 (_sbeParse)
  CMakeLists.txt:69 (sbeParseJson)
```
Given 3.1 is nearly 3 years old, I don't think it's worth investigating. Instead, this PR also bumps the min version to 3.2.


## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
