### PR TITLE
Include duplicate restriction edges in cnbg-ebg mapping

### DIFF
--- a/src/extractor/edge_based_graph_factory.cpp
+++ b/src/extractor/edge_based_graph_factory.cpp
@@ -412,6 +412,13 @@ EdgeBasedGraphFactory::GenerateEdgeExpandedNodes(const WayRestrictionMap &way_re
             m_edge_based_node_distances.push_back(
                 m_edge_based_node_distances[nbe_to_ebn_mapping[eid]]);
 
+            // Include duplicate nodes in cnbg to ebg mapping. This means a
+            // compressed node pair (u,v) can appear multiple times in this list.
+            // This is needed by the MLD partition step to ensure duplicate nodes
+            // are also assigned to partitions (the MLD partitioner is currently
+            // the only consumer of this mapping).
+            mapping.push_back(NBGToEBG{node_u, node_v, edge_based_node_id, SPECIAL_NODEID});
+
             edge_based_node_id++;
             progress.PrintStatus(progress_counter++);
         }

--- a/src/partitioner/partitioner.cpp
+++ b/src/partitioner/partitioner.cpp
@@ -118,6 +118,10 @@ int Partitioner::Run(const PartitionerConfig &config)
             edge_based_partition_ids[backward_node] = node_based_partition_ids[v];
     }
 
+    BOOST_ASSERT(std::none_of(edge_based_partition_ids.begin(),
+                              edge_based_partition_ids.end(),
+                              [](auto x) { return x == SPECIAL_NODEID; }));
+
     std::vector<Partition> partitions;
     std::vector<std::uint32_t> level_to_num_cells;
     std::tie(partitions, level_to_num_cells) =


### PR DESCRIPTION
Duplicate restriction nodes in the edge-based-graph are currently
not in included in a mapping (.osrm.cnbg_to_ebg) from
node-based-graph edges to edge-based-graph nodes.
This mapping is used by the MLD partitioner to assign EBG nodes
to partitions.

The omission from the mapping means all restriction nodes are
included in a special 'invalid' partition. This special partition
will break the geolocation properties of the multi-level hierarchy.
The partition and its super levels will have a large number of
border nodes and very few internal paths between them.

Given the partitioner is the only consumer of the mapping, we fix
the issue by including the duplicate restriction nodes in the mapping,
so that they are correctly assigned to a partition.

This has measurable improvement on MLD routing.
For a country-sized routing network, the fix reduces routing and table
request computation time by ~2% and ~6% respectively and
reduces memory usage by X%.

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

## Tasklist

 - [ ] CHANGELOG.md entry ([How to write a changelog entry](http://keepachangelog.com/en/1.0.0/#how))
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)
 - [ ] review
 - [ ] adjust for comments
 - [ ] cherry pick to release branch

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
